### PR TITLE
fix: audited RegExs fixes #23

### DIFF
--- a/src/OldManBot/responses/bullyisms.ts
+++ b/src/OldManBot/responses/bullyisms.ts
@@ -1,6 +1,6 @@
 import { Response } from '../../DiscordBot/Managers/ResponseManager'
 
-const BULLY_TEMPLATE = RegExp('(with|my) friends and (.+)')
+const BULLY_TEMPLATE = RegExp('(with|my) friends and (.+)', 'gi')
 const BULLY_TEMPLATE_RESPONSE = msg => {
   const weakling = msg.match(BULLY_TEMPLATE)[2]
   return `Haha, yeah, fuck ${weakling}, that BITCH!`

--- a/src/tests/OldManBot/responses/bullyisms.test.ts
+++ b/src/tests/OldManBot/responses/bullyisms.test.ts
@@ -30,6 +30,12 @@ describe('bullyisms', () => {
     ).toBeTruthy()
 
     expect(
+      bullyTemplate.isTriggered(
+        'Its been FUN hanging out with Friends and john and other People'
+      )
+    ).toBeTruthy()
+
+    expect(
       bullyTemplate.isTriggered('this sentence shouldnt trigger')
     ).toBeFalsy()
   })

--- a/src/tests/OldManBot/responses/offensives.test.ts
+++ b/src/tests/OldManBot/responses/offensives.test.ts
@@ -9,5 +9,9 @@ describe('offensives', () => {
   })
   test('ok boomer', () => {
     expect(boomer.isTriggered('ok boomer')).toBeTruthy()
+    expect(boomer.isTriggered('ok, boomer')).toBeTruthy()
+    expect(boomer.isTriggered('OK, boomer')).toBeTruthy()
+    expect(boomer.isTriggered('Ok, Boomer')).toBeTruthy()
+    expect(boomer.isTriggered('Ok Boomer')).toBeTruthy()
   })
 })


### PR DESCRIPTION
Audited some regexes. Turns out most of what Cletus was nagging about was just the random probability of the trigger. Nonetheless added some tests and made a few more RegExs case insensitive.